### PR TITLE
Ralph: #2

### DIFF
--- a/src/components/editable-text/editable-text.stories.tsx
+++ b/src/components/editable-text/editable-text.stories.tsx
@@ -1,0 +1,272 @@
+import { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react'
+import { EditableText, type EditableTextVariant } from './editable-text'
+import { Button } from '../button'
+import { createIcon } from '../icon'
+
+const GitHubIcon = createIcon('github')
+const FigmaIcon = createIcon('figma')
+
+/** Simulates async save with a 500ms delay */
+const fakeSave = async () => {
+  await new Promise((r) => setTimeout(r, 500))
+}
+
+/** Simulates a save that rejects */
+const failingSave = async () => {
+  await new Promise((r) => setTimeout(r, 300))
+  throw new Error('Name already taken')
+}
+
+const meta: Meta<typeof EditableText> = {
+  title: 'Application/EditableText',
+  component: EditableText,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['field', 'title'],
+      description: 'Visual variant — field (default) or title',
+      table: { category: 'Appearance' },
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md'],
+      description: 'Text size (only applies to field variant)',
+      table: { category: 'Appearance' },
+    },
+    type: {
+      control: 'select',
+      options: ['text', 'email', 'url', 'tel'],
+      description: 'HTML input type',
+      table: { category: 'Behavior' },
+    },
+    editable: {
+      control: 'boolean',
+      description: 'Whether the field is editable',
+      table: { category: 'State' },
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the field is disabled',
+      table: { category: 'State' },
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Input placeholder text',
+      table: { category: 'Content' },
+    },
+    emptyText: {
+      control: 'text',
+      description: 'Text shown when value is empty',
+      table: { category: 'Content' },
+    },
+    className: {
+      control: false,
+      table: { category: 'Advanced' },
+    },
+  },
+  args: {
+    value: 'Acme Corporation',
+    onSave: fakeSave,
+    variant: 'field',
+    editable: true,
+    disabled: false,
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof EditableText>
+
+// =============================================================================
+// OVERVIEW (default - all variants by property)
+// =============================================================================
+
+const OverviewField = () => {
+  const [val, setVal] = useState('Acme Corporation')
+  return (
+    <EditableText
+      value={val}
+      variant="field"
+      onSave={async (v) => {
+        await fakeSave()
+        setVal(v)
+      }}
+    />
+  )
+}
+
+const OverviewTitle = () => {
+  const [val, setVal] = useState('Project Alpha')
+  return (
+    <EditableText
+      value={val}
+      variant="title"
+      onSave={async (v) => {
+        await fakeSave()
+        setVal(v)
+      }}
+    />
+  )
+}
+
+export const Overview: Story = {
+  render: () => {
+    const variants: EditableTextVariant[] = ['field', 'title']
+
+    return (
+      <div className="flex flex-col gap-10 px-12 pb-12 pt-8" style={{ minWidth: 480 }}>
+        {/* Variant */}
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-tertiary">Variant</span>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-quaternary">field (default)</span>
+              <div style={{ maxWidth: 320 }}>
+                <OverviewField />
+              </div>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-quaternary">title — inside an {'<h1>'}</span>
+              <h1 className="text-display-sm font-semibold">
+                <OverviewTitle />
+              </h1>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-quaternary">title — inside an {'<h2>'}</span>
+              <h2 className="text-display-xs font-semibold">
+                <OverviewTitle />
+              </h2>
+            </div>
+          </div>
+        </div>
+
+        {/* Empty state */}
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-tertiary">Empty State</span>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-quaternary">field — empty</span>
+              <div style={{ maxWidth: 320 }}>
+                <EditableText value={null} onSave={fakeSave} emptyText="Add company name" />
+              </div>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-quaternary">title — empty</span>
+              <h1 className="text-display-sm font-semibold">
+                <EditableText value={null} variant="title" onSave={fakeSave} emptyText="Untitled" />
+              </h1>
+            </div>
+          </div>
+        </div>
+
+        {/* Disabled */}
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-tertiary">Disabled</span>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-quaternary">field — disabled</span>
+              <div style={{ maxWidth: 320 }}>
+                <EditableText value="Locked value" onSave={fakeSave} disabled />
+              </div>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-quaternary">title — disabled</span>
+              <h1 className="text-display-sm font-semibold">
+                <EditableText value="Locked title" variant="title" onSave={fakeSave} disabled />
+              </h1>
+            </div>
+          </div>
+        </div>
+
+        {/* Not editable */}
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-tertiary">Read-only (editable=false)</span>
+          <div className="flex flex-col gap-4">
+            <div style={{ maxWidth: 320 }}>
+              <EditableText value="Plain text" onSave={fakeSave} editable={false} />
+            </div>
+          </div>
+        </div>
+
+        {/* Error */}
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-tertiary">Error on save</span>
+          <p className="text-xs text-quaternary">Edit and press Enter — save will reject</p>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-quaternary">field</span>
+              <div style={{ maxWidth: 320 }}>
+                <EditableText value="Edit me" onSave={failingSave} />
+              </div>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-quaternary">title</span>
+              <h2 className="text-display-xs font-semibold">
+                <EditableText value="Edit me" variant="title" onSave={failingSave} />
+              </h2>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  },
+}
+
+// =============================================================================
+// PROPS (with controls)
+// =============================================================================
+
+export const Props: Story = {
+  tags: ['show-panel'],
+  args: {
+    value: 'Acme Corporation',
+    variant: 'field',
+    editable: true,
+    disabled: false,
+    type: 'text',
+    placeholder: 'Enter a value...',
+    emptyText: 'Add',
+  },
+  render: (args) => (
+    <div style={{ minWidth: 320 }}>
+      <EditableText {...args} onSave={fakeSave} />
+    </div>
+  ),
+}
+
+// =============================================================================
+// SOURCE CODE + DESIGN
+// =============================================================================
+
+export const SourceCodeAndDesign: Story = {
+  name: 'Source Code + Design',
+  render: () => (
+    <div className="flex min-w-[480px] flex-col items-center gap-8 py-12">
+      <div className="flex flex-col items-center gap-4 text-center">
+        <h2 className="text-display-xs font-semibold text-primary">Source Code + Figma Design</h2>
+        <p className="text-md text-tertiary">This component was built from the Untitled Design System</p>
+      </div>
+      <div className="flex gap-4">
+        <Button
+          href="https://github.com/PlayaLink/untitled-ds/tree/main/src/components/editable-text"
+          target="_blank"
+          iconLeading={GitHubIcon}
+          color="secondary"
+        >
+          View on GitHub
+        </Button>
+        <Button
+          href="https://www.figma.com/design/99BhJBqUTbouPjng6udcbz/Unified-Design-System--Untitled-UI-?node-id=1-2831"
+          target="_blank"
+          iconLeading={FigmaIcon}
+          color="primary"
+        >
+          View in Figma
+        </Button>
+      </div>
+    </div>
+  ),
+}

--- a/src/components/editable-text/editable-text.tsx
+++ b/src/components/editable-text/editable-text.tsx
@@ -4,6 +4,8 @@ import { useRef, useEffect } from 'react'
 import { useEditableField } from '@/hooks/use-editable-field'
 import { cx } from '@/utils/cx'
 
+export type EditableTextVariant = 'field' | 'title'
+
 export interface EditableTextProps {
   value: string | null
   onSave: (newValue: string) => Promise<void>
@@ -13,6 +15,7 @@ export interface EditableTextProps {
   editable?: boolean
   disabled?: boolean
   size?: 'sm' | 'md'
+  variant?: EditableTextVariant
   className?: string
 }
 
@@ -25,6 +28,7 @@ export const EditableText = ({
   editable = true,
   disabled,
   size = 'sm',
+  variant = 'field',
   className,
 }: EditableTextProps) => {
   const field = useEditableField({ value: value ?? '' })
@@ -50,16 +54,21 @@ export const EditableText = ({
     return <span className={className}>{value}</span>
   }
 
-  // READING state — dormant-input tint button
+  // READING state — dormant-input tint button (field) or plain text (title)
   if (field.state === 'READING') {
+    const isTitle = variant === 'title'
     return (
       <button
         type="button"
         data-state={field.state}
+        data-variant={variant}
         onClick={field.edit}
         disabled={disabled}
         className={cx(
-          'w-full rounded-md bg-secondary px-2 py-1 text-left text-md text-primary',
+          'w-full text-left text-primary',
+          isTitle
+            ? 'inline rounded-sm decoration-tertiary underline-offset-4 hover:underline'
+            : 'rounded-md bg-secondary px-2 py-1 text-md',
           disabled && 'cursor-not-allowed opacity-50',
           className,
         )}
@@ -72,8 +81,9 @@ export const EditableText = ({
   }
 
   // EDITING / SAVING / ERROR — active input
+  const isTitle = variant === 'title'
   return (
-    <div data-state={field.state} className={cx('w-full', className)}>
+    <div data-state={field.state} data-variant={variant} className={cx('w-full', className)}>
       <div className="relative">
         <input
           ref={inputRef}
@@ -88,7 +98,8 @@ export const EditableText = ({
           }}
           onBlur={field.commit}
           className={cx(
-            'w-full rounded-md px-2 py-1 text-md text-primary bg-primary ring-1 ring-border-primary ring-inset outline-none',
+            'w-full rounded-md px-2 py-1 text-primary bg-primary ring-1 ring-border-primary ring-inset outline-none',
+            isTitle ? 'text-[inherit] font-[inherit]' : 'text-md',
             'focus:ring-2 focus:ring-border-brand',
             field.state === 'SAVING' && 'animate-pulse',
             field.state === 'ERROR' && 'ring-border-error',

--- a/src/components/editable-text/index.ts
+++ b/src/components/editable-text/index.ts
@@ -1,1 +1,1 @@
-export { EditableText, type EditableTextProps } from './editable-text'
+export { EditableText, type EditableTextProps, type EditableTextVariant } from './editable-text'

--- a/src/index.ts
+++ b/src/index.ts
@@ -248,7 +248,7 @@ export {
 export { FullscreenOverlay, type FullscreenOverlayProps } from './components/fullscreen-overlay'
 
 // Editable Text
-export { EditableText, type EditableTextProps } from './components/editable-text'
+export { EditableText, type EditableTextProps, type EditableTextVariant } from './components/editable-text'
 
 // Editable TextArea
 export { EditableTextArea, type EditableTextAreaProps } from './components/editable-textarea'


### PR DESCRIPTION
## Ralph Worker

**Branch:** `claude/editable-text-variant-title-1774337086`
**Issues:** #2

### Task

Implement issue #2: Add a `variant` prop to the `EditableText` component.

**File to modify:** `src/components/editable-text/editable-text.tsx`

**New prop:** `variant?: "field" | "title"` (default: `"field"`)

**Behavior for `variant="title"`:**
- Reading state: No background color, no tinted fill — text appears as plain heading text. Add a subtle hover indicator (e.g., underline or pencil icon) to signal editability.
- Text size: Inherits from parent element — does NOT apply a `size`-based class. When placed inside an `<h1>`, it renders at heading size.
- Editing state: Same input behavior as `"field"` variant.
- Saving/Error states: Same as `"field"` variant.

**Behavior for `variant="field"` (default):** Identical to current implementation — no regression.

**After implementation:**
1. Update Storybook stories to show both variants (add examples of `variant="title"` in the Overview story).
2. Run `npm run build:lib` and confirm it passes.

**Acceptance criteria (from issue #2):**
- `EditableText` accepts `variant` prop with `"field"` (default) and `"title"` options
- `variant="field"` behaves identically to current implementation
- `variant="title"` has no background/tint in reading state
- `variant="title"` inherits text size from parent element (no size class applied)
- `variant="title"` shows a hover indicator for editability
- Editing, saving, and error states work correctly for both variants
- `npm run build:lib` passes
- Storybook stories updated to show both variants

Reference issue #2 in your commit message.

### Commits

```
8d23d72 feat(editable-text): add variant prop with field and title modes (#2)
```

---
*Created by [ralph](https://github.com/PlayaLink/ralph) — autonomous AI coding agent loop.*